### PR TITLE
进行一个bug的修复

### DIFF
--- a/dist/spritejs.js
+++ b/dist/spritejs.js
@@ -27774,7 +27774,7 @@ function getCurrentFrame(timing, keyframes, effects, p) {
       var ep = p;
       if (_easing) {
         var d = offset - previousOffset;
-        ep = _easing((p - previousOffset) / d) * d + previousOffset;
+        ep = _easing((p - previousOffset) / d，keyframes) * d + previousOffset;
       }
 
       if (effect) {


### PR DESCRIPTION
对于这样的代码，库会报错：
```
//已经创建了一个名为sp的Sprite
sp.animate([
		{y:600,offset:0.25},
		{y:580,offset:0.75,easing:"step-end"},
		{y:560,offset:1}
	],{
		fill:"forwards",
		duration:1000
	}
);
```
经检查,是一处函数放少了参数。请有人合并下，并修复其他库的该问题。